### PR TITLE
Skip missing folders

### DIFF
--- a/app/scripts/compose_json_files.py
+++ b/app/scripts/compose_json_files.py
@@ -31,6 +31,9 @@ def create_list(in_dir, group_name, subfolders):
 def accumulate_json_files(dir_path):
     acc = []
 
+    if not dir_path.exists():
+        return acc
+
     for file_name in os.listdir(dir_path):
         file_path = dir_path / file_name
         if file_path.is_file():


### PR DESCRIPTION
Fixes #23 

Checks whether a directory exists before trying to list its contents.