### PR TITLE
Handling nodes with no arguments

### DIFF
--- a/chatbot/insert/check_integrity.js
+++ b/chatbot/insert/check_integrity.js
@@ -70,8 +70,24 @@ function check_integrity(object, ExcelLogPath = "") {
             for (const action of node.actions) {
                 if (action.type == 'send_msg') {                    
                     if (action.quick_replies.length > 0) {
-                        TotalQRNodes++                                                
-                        [debug, debug_lang] = log_integrity(flow, node, action, curr_loc, routers, debug, debug_lang, ExcelLogPath);                        
+                        TotalQRNodes++ 
+                        //Before we start checking if there are problems with the translation we first check if there is an associated wait for response node with arguments
+                        if(routers[node.exits[0].destination_uuid]){                                               
+                            [debug, debug_lang] = log_integrity(flow, node, action, curr_loc, routers, debug, debug_lang, ExcelLogPath);                        
+                        }
+                        else{
+                            if(!debug.includes(flow.uuid)){
+                                TotalProblemFlowsENG++
+                                debug += `    Problem flow: ${TotalProblemFlowsENG}\n`
+                                debug += `    Flow ID: ${flow.uuid}\n`
+                                debug += `    Flow name: ${flow.name}\n\n`
+                            }
+                        
+                            TotalProblemNodesENG++
+                            debug += `        QR Node ID: ${node.uuid}\n`
+                            debug += `        Action text: ${action.text.replace(/(\r\n|\n|\r)/gm, "; ")}\n`
+                            debug += '        NO ASSOCIATED ARGUMENT NODE\n\n'
+                        }
                     }
                 }
             }

--- a/chatbot/insert/fix_arg_qr_translation.js
+++ b/chatbot/insert/fix_arg_qr_translation.js
@@ -62,20 +62,25 @@ function fix_arg_qr_translation(object) {
 
         // Loop through the nodes looking for ones with quick replies, if we find quick replies we will check the link to the arguments and potentially fix the translation if it does not match the english
         for (const node of flow.nodes) {
+            
             for (const action of node.actions) {
                 if (action.type == 'send_msg') {                    
                     if (action.quick_replies.length > 0) {
-                        TotalQRNodes++                                                
-                        [debug_lang, modified_arguments, modified_argument_IDs, modified_argument_lang] = fix_translated_arguments(flow, node, action, curr_loc, routers, debug_lang);
-                        
-                        //We need to take our modified arguments and insert them back into the main object so we can export a fixed version
-                        //console.log(modified_argument_IDs)
-                        for(const row in modified_arguments){                            
-                            curr_loc[modified_argument_lang[row]][modified_argument_IDs[row]].arguments[0] = modified_arguments[row]
+                        TotalQRNodes++     
+                        //Before we start checking if there are problems with the translation we first check if there is an associated wait for response node with arguments
+                        if(routers[node.exits[0].destination_uuid]){                                           
+                            [debug_lang, modified_arguments, modified_argument_IDs, modified_argument_lang] = fix_translated_arguments(flow, node, action, curr_loc, routers, debug_lang);
+                            
+                            //We need to take our modified arguments and insert them back into the main object so we can export a fixed version
+                            //console.log(modified_argument_IDs)
+                            for(const row in modified_arguments){                            
+                                curr_loc[modified_argument_lang[row]][modified_argument_IDs[row]].arguments[0] = modified_arguments[row]
+                            }
                         }
                     }
                 }
             }
+            
         }        
     }
     


### PR DESCRIPTION
Sorry for the delay, fixes #21 , log file in the 'overall_integrity_check' should now indicate nodes which have no arguments. Those same nodes should also not cause the script to crash.

@fagiothree can you check with one of the original examples that you were using and that you are happy how the comments are recorded.

Looking through this again I also appreciate how this code is a bit of a mess, something which I think @istride also noted! Not an immediate issue but may be an idea to refactor this code a bit in the future, was built up incrementally as we were looking for new functionality so things could be simplified a little I think.