### PR TITLE
Adding new function to format quick replies

### DIFF
--- a/chatbot/index.js
+++ b/chatbot/index.js
@@ -6,7 +6,7 @@ const integrity = require('./insert/check_integrity.js')
 const fixer = require('./insert/fix_arg_qr_translation.js')
 const ex = require('./extract/extract.js');
 const insert = require('./insert/create-localization.js');
-const { move_quick_replies_to_message_text } = require('./insert/add_quick_replies_to_msg_text_and_localization.js');
+const modifyqr = require('./insert/modify_quick_replies.js');
 
 const COMMANDS = {
     has_any_words_check,
@@ -14,7 +14,8 @@ const COMMANDS = {
     fix_arg_qr_translation,
     extract,
     localize,
-    move_quick_replies
+    move_quick_replies,
+    reformat_quick_replies
 };
 const args = process.argv.slice(2);
 const command = args.shift();
@@ -86,9 +87,23 @@ function move_quick_replies([input_file, select_phrases, outputName, outputDir, 
         special_words = readInputFile(special_words)
     }
 
-    const [flows, debug, debug_lang] = move_quick_replies_to_message_text(
+    const [flows, debug, debug_lang] = modifyqr.move_quick_replies_to_message_text(
         readInputFile(input_file),readInputFile(select_phrases), add_selectors, special_words
     );
+    writeOutputFile(outputDir, outputName + '.json', flows);
+    writeOutputFile(outputDir, 'debug_qr.txt', debug);
+    for (lang in debug_lang){
+        writeOutputFile(outputDir, 'debug_qr_' + lang +'.txt', debug_lang[lang]);
+    }
+}
+
+function reformat_quick_replies([input_file, select_phrases, outputName, outputDir, count_threshold = 1, length_threshold = 1, special_words = false]) {
+
+    if(special_words != false){
+        special_words = readInputFile(special_words)
+    }
+
+    const [flows, debug, debug_lang] = modifyqr.reformat_quick_replies(readInputFile(input_file), readInputFile(select_phrases), Number(count_threshold), Number(length_threshold), special_words)
     writeOutputFile(outputDir, outputName + '.json', flows);
     writeOutputFile(outputDir, 'debug_qr.txt', debug);
     for (lang in debug_lang){

--- a/chatbot/insert/modify_quick_replies.js
+++ b/chatbot/insert/modify_quick_replies.js
@@ -54,7 +54,7 @@ function move_quick_replies_to_message_text(flows, select_phrases, add_selectors
                         
                         add_quick_replies_to_msg_text(action, quick_replies, curr_loc, select_phrases);
                         
-                        clear_quick_replies(node, routers, action, curr_loc, quick_replies, add_selectors, special_words, debug, debug_lang);
+                        clear_quick_replies(node, routers, action, curr_loc, quick_replies, add_selectors, special_words, debug, debug_lang, count_threshold, length_threshold);
                         
                         modify_router_node_cases(node, action, curr_loc, quick_replies, routers, debug, debug_lang, routers_edited);
                         
@@ -65,6 +65,86 @@ function move_quick_replies_to_message_text(flows, select_phrases, add_selectors
     }
 
     return [flows, debug, debug_lang];
+}
+
+function reformat_quick_replies(flows, select_phrases, count_threshold, length_threshold, special_words) {
+    
+    const exceptions = [
+        'no',
+        'prefer not to say',
+        'prefer not to answer',
+        'prefer not to tell',
+        'i prefer not to tell',
+        'does not apply',
+        'go back to the previous options',
+        'i am not interested',
+        'no i do not agree'
+    ];
+
+    let debug = '';
+    let debug_lang = {};
+    if (!select_phrases.hasOwnProperty("eng")){
+        select_phrases["eng"] = "Please select the number for the following options:"
+    }
+ 
+    for (const flow of flows.flows) {
+        
+        let curr_loc = flow.localization;
+
+        debug += `\n\n${flow.name}*************************************\n`;
+        for (const lang in curr_loc) {
+            
+            if (debug_lang.hasOwnProperty(lang)){
+                debug_lang[lang] += `\n\n${flow.name}*************************************\n`;
+            }else{
+                debug_lang[lang] = `${flow.name}*************************************\n`;
+            }
+ 
+        }
+
+        const routers = flow.nodes
+            .filter((node) => node.router && node.router.operand === '@input.text')
+            .reduce(
+                (acc, node) => {
+                    acc[node.uuid] = node;
+                    return acc;
+                },
+                {}
+            );
+        
+        let routers_edited = []
+
+        for (const node of flow.nodes) {
+            for (const action of node.actions) {
+                if (action.type == 'send_msg') {
+                    if (action.quick_replies.length > 0) {
+                        let max_qr_length = find_max_length(action.quick_replies)
+                        if(action.quick_replies.lenght > count_threshold || max_qr_length > length_threshold){
+                            let quick_replies = augment_quick_replies(action, exceptions, curr_loc);
+                        
+                            add_quick_replies_to_msg_text(action, quick_replies, curr_loc, select_phrases);
+                            
+                            clear_quick_replies(node, routers, action, curr_loc, quick_replies, "yes", special_words, debug, debug_lang);
+                            
+                            modify_router_node_cases(node, action, curr_loc, quick_replies, routers, debug, debug_lang, routers_edited);
+                        }                       
+                    }
+                }
+            }
+        }
+    }
+
+    return [flows, debug, debug_lang];
+}
+
+function find_max_length(quick_replies) {
+    let max_length = 1
+    for (const qr of quick_replies) {
+        if (qr.length > max_length){
+            max_length = qr.length
+        }
+    }
+    return max_length
 }
 
 function augment_quick_replies(curr_act, exceptions, curr_loc) {
@@ -107,7 +187,7 @@ function add_quick_replies_to_msg_text(action, quick_replies, curr_loc, select_p
     }
 }
 
-function clear_quick_replies(node, routers, action, curr_loc, quick_replies, add_selectors, special_words, debug, debug_lang) {
+function clear_quick_replies(node, routers, action, curr_loc, quick_replies, add_selectors, special_words, debug, debug_lang, count_threshold = 1, length_threshold = 1) {
     // id of corresponding wait for response node
     const dest_id = node.exits[0].destination_uuid;
     let router = routers[dest_id];
@@ -293,5 +373,6 @@ function split_string(args) {
 }
 
 module.exports = {
-    move_quick_replies_to_message_text
+    move_quick_replies_to_message_text,
+    reformat_quick_replies
 };

--- a/chatbot/insert/modify_quick_replies.js
+++ b/chatbot/insert/modify_quick_replies.js
@@ -117,9 +117,10 @@ function reformat_quick_replies(flows, select_phrases, count_threshold, length_t
         for (const node of flow.nodes) {
             for (const action of node.actions) {
                 if (action.type == 'send_msg') {
-                    if (action.quick_replies.length > 0) {
+                    qr_count = action.quick_replies.length
+                    if (qr_count > 1) { 
                         let max_qr_length = find_max_length(action.quick_replies)
-                        if(action.quick_replies.length > count_threshold || max_qr_length > length_threshold){
+                        if(qr_count > count_threshold || max_qr_length > length_threshold){
                             let quick_replies = augment_quick_replies(action, exceptions, curr_loc);
                         
                             add_quick_replies_to_msg_text(action, quick_replies, curr_loc, select_phrases);

--- a/chatbot/insert/modify_quick_replies.js
+++ b/chatbot/insert/modify_quick_replies.js
@@ -119,7 +119,7 @@ function reformat_quick_replies(flows, select_phrases, count_threshold, length_t
                 if (action.type == 'send_msg') {
                     if (action.quick_replies.length > 0) {
                         let max_qr_length = find_max_length(action.quick_replies)
-                        if(action.quick_replies.lenght > count_threshold || max_qr_length > length_threshold){
+                        if(action.quick_replies.length > count_threshold || max_qr_length > length_threshold){
                             let quick_replies = augment_quick_replies(action, exceptions, curr_loc);
                         
                             add_quick_replies_to_msg_text(action, quick_replies, curr_loc, select_phrases);

--- a/chatbot/insert/modify_quick_replies.js
+++ b/chatbot/insert/modify_quick_replies.js
@@ -54,7 +54,7 @@ function move_quick_replies_to_message_text(flows, select_phrases, add_selectors
                         
                         add_quick_replies_to_msg_text(action, quick_replies, curr_loc, select_phrases);
                         
-                        clear_quick_replies(node, routers, action, curr_loc, quick_replies, add_selectors, special_words, debug, debug_lang, count_threshold, length_threshold);
+                        clear_quick_replies(node, routers, action, curr_loc, quick_replies, add_selectors, special_words, debug, debug_lang);
                         
                         modify_router_node_cases(node, action, curr_loc, quick_replies, routers, debug, debug_lang, routers_edited);
                         

--- a/chatbot/package.json
+++ b/chatbot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idems/idems_translation_chatbot",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Translation tools for chatbots",
   "main": "index.js",
   "scripts": {

--- a/chatbot/package.json
+++ b/chatbot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idems/idems_translation_chatbot",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Translation tools for chatbots",
   "main": "index.js",
   "scripts": {

--- a/chatbot/package.json
+++ b/chatbot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idems/idems_translation_chatbot",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Translation tools for chatbots",
   "main": "index.js",
   "scripts": {

--- a/chatbot/package.json
+++ b/chatbot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idems/idems_translation_chatbot",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "description": "Translation tools for chatbots",
   "main": "index.js",
   "scripts": {

--- a/chatbot/test/qr-to-msg-text-test.js
+++ b/chatbot/test/qr-to-msg-text-test.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const assert = require('assert');
-const modify = require('../insert/add_quick_replies_to_msg_text_and_localization.js');
+const modify = require('../insert/modify_quick_replies.js');
 
 function readInputFile(filePath) {
     return JSON.parse(fs.readFileSync(filePath).toString());


### PR DESCRIPTION
After discussions with @fagiothree , have added an additional function to this repo related to 'formatting quick replies'. The functionality is similar to an existing function but has different use cases. 

We essentially have 2 use cases around quick replies:

1) **Move_quick_replies (existing)** 
We want to move QR to message text so people can use it on basic devices which don't support QR buttons. We add the quick replies to the message text and number them so the user can proceed by entering a number as free text. There is an option here where we can add numerical QR back in so that users with QR compatible devices can still use them. At this point we are currently checking 'special_words' and those QR go back in as full and not just numbers. We could add some extra conditions here to maybe leave more QR as complete (not just numbers) but at the moment I have not made any changes to this function. Crucially in this use case we always need to make the platform usable if QR do not appear, so we always need to modify the original message text.

2) **Reformat_quick_replies (new)**
We have users who we know can use QR, but we want to reformat the QR so that they are easier to use. Basically where there are lots of quick replies or long quick replies it may be better to number the quick replies and add them to the message text as it may display better on the user's device. We introduce two new parameters:

- count_threshold (relates to number of quick replies)
- length_threshold (relates to length of the longest quick reply)

With this function we check the QRs against the count_threshold and length_threshold, if the number of QRs is below or equal the count_threshold and the longest QR is shorter than or equal to the length_threshold then the QR are to be left in place the node will not be changed. In places where the QR are too long. We will make the changes to make the QRs numbers and add the number references to the message text as example 1.

It seems to me that these form parallel paths in the pipeline around the 'deployment channel optimisation step', so we can choose to do 1 or 2 depending on our target audience. 

Point of discussion: at the moment everything is operating on the english text, could extend to consider translation lengths, but hopefully english is a somewhat good gauge of general length of the quick replies.

@fagiothree could you review the above and see if that makes sense/ is fit for purpose

