### PR TITLE
FacilitatorApp MY insert empty string in splitgps

### DIFF
--- a/app/config_files/plh_facilitator_my_settings.json
+++ b/app/config_files/plh_facilitator_my_settings.json
@@ -2,7 +2,7 @@
     "CoreFiles": "../parenting-app-ui/.idems_app/deployments/plh_facilitator_my/app_data/sheets",
     "ComposeResult": "app/1_compose_result",
     "CoreGroups": [["data_list", ["campaign_rows", "campaign_schedule", "legal_terms"]],["global", ["legal_terms"]],["template", ["legal_terms"]],["tour", [""]]],
-    "SplitGroups": [["main"], ["legal_terms"]],
+    "SplitGroups": [["main",""], ["legal_terms",""]],
     "ExtractResult": "app/2_extract_result",
     "ReadyForTranslation": "app/3_ready_for_translators",
     "PostTranslation": ["../PLH-Digital-Content/translations/facilitator_app_malaysia"],


### PR DESCRIPTION
Running 
```
py app/scripts/prepare_for_translation.py app\config_files\plh_facilitator_my_settings.json
```
only works correctly when the proposed changes are made to `plh_facilitator_my_settings.json`, that is, the SplitGroups each contain two items. Otherwise, I get the error 
```
Traceback (most recent call last):
  File "C:\Users\Esmee\Documents\GitHub\idems_translation\app\scripts\prepare_for_translation.py", line 40, in <module>
    main()
  File "C:\Users\Esmee\Documents\GitHub\idems_translation\app\scripts\prepare_for_translation.py", line 26, in main
    dest_path = group_info[1]
IndexError: list index out of range
```
<img width="684" alt="image" src="https://github.com/IDEMSInternational/idems_translation/assets/74557272/55acff7f-d5c9-4da6-9dd3-bca62775ca88">

@edmoss345 Could you see if you can fix this in the `prepare_for_translation.py` script? 
If yes, we can undo the changes in my commit. 
If no, we can just merge this as is because this does provide a work-around.